### PR TITLE
Add Google login and refresh UI for calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # testing-online-coding
 
-A small Flask web app that adds two numbers.
+A small Flask web app that adds two numbers. It now requires a Google login so
+only an authorized Gmail account can use the calculator.
 
 ## Setup
 
@@ -12,6 +13,15 @@ pip install -r requirements.txt
 
 ```bash
 python app.py
+```
+Set the following environment variables with your Google OAuth credentials and
+the email allowed to use the app:
+
+```bash
+export GOOGLE_CLIENT_ID="your-client-id"
+export GOOGLE_CLIENT_SECRET="your-client-secret"
+export AUTHORIZED_EMAIL="user@example.com"
+export SECRET_KEY="choose-a-secret"
 ```
 
 Then open `http://localhost:5000/` in your browser.

--- a/app.py
+++ b/app.py
@@ -1,18 +1,69 @@
-from flask import Flask, request, render_template
+import os
+from flask import (
+    Flask,
+    request,
+    render_template,
+    redirect,
+    url_for,
+    session,
+)
+from authlib.integrations.flask_client import OAuth
 
 app = Flask(__name__)
+app.secret_key = os.environ.get("SECRET_KEY", "dev-secret-key")
 
-@app.route('/', methods=['GET', 'POST'])
+oauth = OAuth(app)
+google = oauth.register(
+    name="google",
+    client_id=os.environ.get("GOOGLE_CLIENT_ID"),
+    client_secret=os.environ.get("GOOGLE_CLIENT_SECRET"),
+    access_token_url="https://accounts.google.com/o/oauth2/token",
+    authorize_url="https://accounts.google.com/o/oauth2/auth",
+    api_base_url="https://www.googleapis.com/oauth2/v2/",
+    userinfo_endpoint="https://www.googleapis.com/oauth2/v2/userinfo",
+    client_kwargs={"scope": "openid email profile"},
+)
+ALLOWED_EMAIL = os.environ.get("AUTHORIZED_EMAIL")
+
+
+@app.route("/login")
+def login():
+    redirect_uri = url_for("authorize", _external=True)
+    return google.authorize_redirect(redirect_uri)
+
+
+@app.route("/authorize")
+def authorize():
+    token = google.authorize_access_token()
+    resp = google.get("userinfo")
+    user_info = resp.json()
+    email = user_info.get("email")
+    if ALLOWED_EMAIL and email != ALLOWED_EMAIL:
+        return "Unauthorized", 403
+    session["user"] = email
+    return redirect(url_for("index"))
+
+
+@app.route("/logout")
+def logout():
+    session.pop("user", None)
+    return redirect(url_for("index"))
+
+
+@app.route("/", methods=["GET", "POST"])
 def index():
+    if "user" not in session:
+        return redirect(url_for("login"))
     result = None
-    if request.method == 'POST':
+    if request.method == "POST":
         try:
-            num1 = float(request.form.get('num1', 0))
-            num2 = float(request.form.get('num2', 0))
+            num1 = float(request.form.get("num1", 0))
+            num2 = float(request.form.get("num2", 0))
             result = num1 + num2
         except ValueError:
-            result = 'Invalid input'
-    return render_template('index.html', result=result)
+            result = "Invalid input"
+    return render_template("index.html", result=result, user=session.get("user"))
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 Flask
+Authlib
+requests

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,18 +1,53 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
+    <meta charset="UTF-8" />
     <title>Add Two Numbers</title>
+    <link
+        href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
+        rel="stylesheet"
+    />
+    <style>
+        body {
+            background: linear-gradient(to right, #74ebd5, #acb6e5);
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .card {
+            border-radius: 1rem;
+            box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+        }
+    </style>
 </head>
 <body>
-    <h1>Add Two Numbers</h1>
-    <form method="post">
-        <input type="number" name="num1" step="any" required>
-        <input type="number" name="num2" step="any" required>
-        <button type="submit">Add</button>
-    </form>
-    {% if result is not none %}
-    <p>Result: {{ result }}</p>
-    {% endif %}
+<div class="container">
+    <div class="card p-5">
+        <h1 class="mb-4 text-center">Add Two Numbers</h1>
+        <form method="post" class="row g-3">
+            <div class="col-md-5">
+                <input type="number" name="num1" step="any" class="form-control" placeholder="First number" required />
+            </div>
+            <div class="col-md-5">
+                <input type="number" name="num2" step="any" class="form-control" placeholder="Second number" required />
+            </div>
+            <div class="col-md-2 d-grid">
+                <button type="submit" class="btn btn-primary">Add</button>
+            </div>
+        </form>
+        {% if result is not none %}
+        <div class="alert alert-info mt-4 text-center">Result: {{ result }}</div>
+        {% endif %}
+        <div class="text-center mt-3">
+            {% if user %}
+            <p>Logged in as {{ user }} | <a href="{{ url_for('logout') }}">Logout</a></p>
+            {% else %}
+            <a class="btn btn-danger" href="{{ url_for('login') }}">Login with Google</a>
+            {% endif %}
+        </div>
+    </div>
+</div>
 </body>
 </html>

--- a/test_app.py
+++ b/test_app.py
@@ -1,8 +1,14 @@
+import os
+
+os.environ["AUTHORIZED_EMAIL"] = "tester@example.com"
+
 from app import app
 
 
 def test_addition():
     client = app.test_client()
+    with client.session_transaction() as sess:
+        sess["user"] = "tester@example.com"
     response = client.post('/', data={'num1': '2', 'num2': '3'})
     assert b'Result: 5.0' in response.data
 


### PR DESCRIPTION
## Summary
- integrate Google OAuth login restricting access to one authorized Gmail
- restyle calculator with Bootstrap and gradient design
- document required Google credentials and email

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4b5463a888327a1f4c47486a813aa